### PR TITLE
[REFACTOR] 로그인 및 토큰 재발급 api 연결

### DIFF
--- a/app/src/main/java/com/puzzling/puzzlingaos/data/datasource/local/UserDataSource.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/datasource/local/UserDataSource.kt
@@ -8,8 +8,9 @@ import kotlinx.serialization.json.Json
 import org.apache.commons.lang3.SerializationException
 import java.io.InputStream
 import java.io.OutputStream
+import javax.inject.Inject
 
-object UserDataSource : Serializer<User> {
+class UserDataSource @Inject constructor() : Serializer<User> {
     override val defaultValue: User
         get() = User()
 

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/datasource/local/UserDataSource.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/datasource/local/UserDataSource.kt
@@ -1,0 +1,38 @@
+package com.puzzling.puzzlingaos.data.datasource.local
+
+import androidx.datastore.core.Serializer
+import com.puzzling.puzzlingaos.data.entity.User
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import org.apache.commons.lang3.SerializationException
+import java.io.InputStream
+import java.io.OutputStream
+
+object UserDataSource : Serializer<User> {
+    override val defaultValue: User
+        get() = User()
+
+    override suspend fun readFrom(input: InputStream): User {
+        return try {
+            Json.decodeFromString(
+                deserializer = User.serializer(),
+                string = input.readBytes().decodeToString(),
+            )
+        } catch (e: SerializationException) {
+            e.printStackTrace()
+            defaultValue
+        }
+    }
+
+    override suspend fun writeTo(t: User, output: OutputStream) {
+        withContext(Dispatchers.IO) {
+            output.write(
+                Json.encodeToString(
+                    serializer = User.serializer(),
+                    value = t,
+                ).encodeToByteArray(),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/datasource/remote/AuthDataSource.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/datasource/remote/AuthDataSource.kt
@@ -1,0 +1,10 @@
+package com.puzzling.puzzlingaos.data.datasource.remote
+
+import com.puzzling.puzzlingaos.data.model.response.ResponseLoginDto
+import com.puzzling.puzzlingaos.data.model.response.ResponseTokenDto
+
+interface AuthDataSource {
+    suspend fun login(socialPlatform: String): ResponseLoginDto
+
+    suspend fun getToken(): ResponseTokenDto
+}

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/datasource/remote/impl/AuthDataSourceImpl.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/datasource/remote/impl/AuthDataSourceImpl.kt
@@ -1,0 +1,15 @@
+package com.puzzling.puzzlingaos.data.datasource.remote.impl
+
+import com.puzzling.puzzlingaos.data.datasource.remote.AuthDataSource
+import com.puzzling.puzzlingaos.data.model.response.ResponseLoginDto
+import com.puzzling.puzzlingaos.data.model.response.ResponseTokenDto
+import com.puzzling.puzzlingaos.data.service.AuthService
+import javax.inject.Inject
+
+class AuthDataSourceImpl @Inject constructor(private val apiService: AuthService) : AuthDataSource {
+    override suspend fun login(socialPlatform: String): ResponseLoginDto =
+        apiService.login(socialPlatform)
+
+    override suspend fun getToken(): ResponseTokenDto = apiService.getToken()
+
+}

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/datasource/remote/impl/AuthDataSourceImpl.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/datasource/remote/impl/AuthDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.puzzling.puzzlingaos.data.datasource.remote.impl
 
 import com.puzzling.puzzlingaos.data.datasource.remote.AuthDataSource
+import com.puzzling.puzzlingaos.data.model.request.RequestLoginDto
 import com.puzzling.puzzlingaos.data.model.response.ResponseLoginDto
 import com.puzzling.puzzlingaos.data.model.response.ResponseTokenDto
 import com.puzzling.puzzlingaos.data.service.AuthService
@@ -8,8 +9,7 @@ import javax.inject.Inject
 
 class AuthDataSourceImpl @Inject constructor(private val apiService: AuthService) : AuthDataSource {
     override suspend fun login(socialPlatform: String): ResponseLoginDto =
-        apiService.login(socialPlatform)
+        apiService.login(RequestLoginDto(socialPlatform))
 
     override suspend fun getToken(): ResponseTokenDto = apiService.getToken()
-
 }

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/datasource/remote/impl/AuthDataSourceImpl.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/datasource/remote/impl/AuthDataSourceImpl.kt
@@ -5,11 +5,17 @@ import com.puzzling.puzzlingaos.data.model.request.RequestLoginDto
 import com.puzzling.puzzlingaos.data.model.response.ResponseLoginDto
 import com.puzzling.puzzlingaos.data.model.response.ResponseTokenDto
 import com.puzzling.puzzlingaos.data.service.AuthService
+import com.puzzling.puzzlingaos.data.service.ReIssueTokenService
 import javax.inject.Inject
 
-class AuthDataSourceImpl @Inject constructor(private val apiService: AuthService) : AuthDataSource {
-    override suspend fun login(socialPlatform: String): ResponseLoginDto =
-        apiService.login(RequestLoginDto(socialPlatform))
+class AuthDataSourceImpl @Inject constructor(
+    private val authService: AuthService,
+    private val reIssueTokenService: ReIssueTokenService,
+) : AuthDataSource {
 
-    override suspend fun getToken(): ResponseTokenDto = apiService.getToken()
+    override suspend fun login(socialPlatform: String): ResponseLoginDto =
+        authService.login(RequestLoginDto(socialPlatform))
+
+    override suspend fun getToken(): ResponseTokenDto =
+        reIssueTokenService.getToken()
 }

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/entity/CurrentProject.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/entity/CurrentProject.kt
@@ -1,0 +1,9 @@
+package com.puzzling.puzzlingaos.data.entity
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CurrentProject(
+    val projectId: Int,
+    val projectName: String,
+)

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/entity/KakaoToken.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/entity/KakaoToken.kt
@@ -1,8 +1,0 @@
-package com.puzzling.puzzlingaos.data.entity
-
-import kotlinx.serialization.Serializable
-
-@Serializable
-data class KakaoToken(
-    val accessToken: String? = null,
-)

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/entity/KakaoToken.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/entity/KakaoToken.kt
@@ -1,0 +1,8 @@
+package com.puzzling.puzzlingaos.data.entity
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class KakaoToken(
+    val accessToken: String? = null,
+)

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/entity/Token.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/entity/Token.kt
@@ -5,4 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class Token(
     val accessToken: String? = null,
+    val refreshToken: String? = null,
 )

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/entity/User.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/entity/User.kt
@@ -4,6 +4,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class User(
-    val memberId: Int,
-    val name: String,
+    val memberId: Int? = null,
+    val name: String? = null,
 )

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/entity/User.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/entity/User.kt
@@ -1,0 +1,9 @@
+package com.puzzling.puzzlingaos.data.entity
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class User(
+    val memberId: Int,
+    val name: String,
+)

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/model/request/RequestLoginDto.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/model/request/RequestLoginDto.kt
@@ -1,0 +1,10 @@
+package com.puzzling.puzzlingaos.data.model.request
+
+import com.google.gson.annotations.SerializedName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestLoginDto(
+    @SerializedName("socialPlatform")
+    val socialPlatform: String,
+)

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/model/response/ResponseLoginDto.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/model/response/ResponseLoginDto.kt
@@ -1,6 +1,5 @@
 package com.puzzling.puzzlingaos.data.model.response
 
-import com.puzzling.puzzlingaos.data.entity.Token
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -33,6 +32,4 @@ data class ResponseLoginDto(
         @SerialName("isNewUser")
         val isNewUser: Boolean,
     )
-
-    fun getToken() = Token(data?.accessToken, data?.refreshToken)
 }

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/model/response/ResponseLoginDto.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/model/response/ResponseLoginDto.kt
@@ -7,13 +7,13 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class ResponseLoginDto(
     @SerialName("status")
-    val status: String,
+    val status: Int,
     @SerialName("success")
     val success: Boolean,
     @SerialName("message")
     val message: String,
     @SerialName("data")
-    val data: LoginData?,
+    val data: LoginData,
 
 ) {
     @Serializable
@@ -23,7 +23,9 @@ data class ResponseLoginDto(
         @SerialName("memberId")
         val memberId: Int,
         @SerialName("projectId")
-        val projectId: Int,
+        val projectId: Int?,
+        @SerialName("projectName")
+        val projectName: String?,
         @SerialName("accessToken")
         val accessToken: String,
         @SerialName("refreshToken")

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/model/response/ResponseLoginDto.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/model/response/ResponseLoginDto.kt
@@ -1,5 +1,6 @@
 package com.puzzling.puzzlingaos.data.model.response
 
+import com.puzzling.puzzlingaos.data.entity.Token
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -16,7 +17,6 @@ data class ResponseLoginDto(
 
 ) {
     @Serializable
-
     data class LoginData(
         @SerialName("name")
         val name: String,
@@ -31,4 +31,6 @@ data class ResponseLoginDto(
         @SerialName("isNewUser")
         val isNewUser: Boolean,
     )
+
+    fun getToken() = Token(data?.accessToken, data?.refreshToken)
 }

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/model/response/ResponseLoginDto.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/model/response/ResponseLoginDto.kt
@@ -1,0 +1,34 @@
+package com.puzzling.puzzlingaos.data.model.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseLoginDto(
+    @SerialName("status")
+    val status: String,
+    @SerialName("success")
+    val success: Boolean,
+    @SerialName("message")
+    val message: String,
+    @SerialName("data")
+    val data: LoginData?,
+
+) {
+    @Serializable
+
+    data class LoginData(
+        @SerialName("name")
+        val name: String,
+        @SerialName("memberId")
+        val memberId: Int,
+        @SerialName("projectId")
+        val projectId: Int,
+        @SerialName("accessToken")
+        val accessToken: String,
+        @SerialName("refreshToken")
+        val refreshToken: String,
+        @SerialName("isNewUser")
+        val isNewUser: Boolean,
+    )
+}

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/model/response/ResponseTokenDto.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/model/response/ResponseTokenDto.kt
@@ -1,0 +1,23 @@
+package com.puzzling.puzzlingaos.data.model.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseTokenDto(
+    @SerialName("status")
+    val status: Int,
+    @SerialName("success")
+    val success: Boolean,
+    @SerialName("message")
+    val message: String,
+    @SerialName("date")
+    val data: NewToken?,
+) {
+    @Serializable
+    data class NewToken(
+        @SerialName("accessToken")
+        val accessToken: String,
+
+    )
+}

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/model/response/ResponseTokenDto.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/model/response/ResponseTokenDto.kt
@@ -1,5 +1,6 @@
 package com.puzzling.puzzlingaos.data.model.response
 
+import com.puzzling.puzzlingaos.data.entity.Token
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -20,4 +21,6 @@ data class ResponseTokenDto(
         val accessToken: String,
 
     )
+
+    fun getToken() = Token(data?.accessToken)
 }

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/repository/AuthRepositoryImpl.kt
@@ -16,7 +16,7 @@ class AuthRepositoryImpl @Inject constructor(
         authDataSource.login(socialPlatform).getToken()
     }.onSuccess { token ->
         tokenDataStore.updateData { Token(token.accessToken, token.refreshToken) }
-        Log.d("AuthRepoImpl", "${tokenDataStore.data.first()}")
+        Log.d("AuthRepoImpl", "AuthRepoImpl get 토큰 ${tokenDataStore.data.first()}")
     }.onFailure {
         Log.d("AuthRepoImpl", "$it 에러")
     }

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/repository/AuthRepositoryImpl.kt
@@ -2,21 +2,27 @@ package com.puzzling.puzzlingaos.data.repository
 
 import android.util.Log
 import androidx.datastore.core.DataStore
+import com.puzzling.puzzlingaos.data.datasource.local.UserDataSource
 import com.puzzling.puzzlingaos.data.datasource.remote.AuthDataSource
 import com.puzzling.puzzlingaos.data.entity.Token
+import com.puzzling.puzzlingaos.data.entity.User
+import com.puzzling.puzzlingaos.data.model.response.ResponseLoginDto
 import com.puzzling.puzzlingaos.domain.repository.AuthRepository
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 class AuthRepositoryImpl @Inject constructor(
     private val tokenDataStore: DataStore<Token>,
+    private val userDataSource: DataStore<User>,
     private val authDataSource: AuthDataSource,
 ) : AuthRepository {
-    override suspend fun login(socialPlatform: String): Result<Token> = runCatching {
-        authDataSource.login(socialPlatform).getToken()
-    }.onSuccess { token ->
-        tokenDataStore.updateData { Token(token.accessToken, token.refreshToken) }
-        Log.d("AuthRepoImpl", "AuthRepoImpl get 토큰 ${tokenDataStore.data.first()}")
+    override suspend fun login(socialPlatform: String): Result<ResponseLoginDto> = runCatching {
+        authDataSource.login(socialPlatform)
+    }.onSuccess { result ->
+        tokenDataStore.updateData { Token(result.data.accessToken, result.data.refreshToken) }
+        userDataSource.updateData { User(result.data.memberId, result.data.name) }
+        Log.d("AuthRepoImpl", "$result")
+        Log.d("AuthRepoImpl", "AuthRepoImpl get 토큰 ${userDataSource.data.first()}")
     }.onFailure {
         Log.d("AuthRepoImpl", "$it 에러")
     }

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/repository/AuthRepositoryImpl.kt
@@ -1,0 +1,32 @@
+package com.puzzling.puzzlingaos.data.repository
+
+import android.util.Log
+import androidx.datastore.core.DataStore
+import com.puzzling.puzzlingaos.data.datasource.remote.AuthDataSource
+import com.puzzling.puzzlingaos.data.entity.Token
+import com.puzzling.puzzlingaos.domain.repository.AuthRepository
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+
+class AuthRepositoryImpl @Inject constructor(
+    private val tokenDataStore: DataStore<Token>,
+    private val authDataSource: AuthDataSource,
+) : AuthRepository {
+    override suspend fun login(socialPlatform: String): Result<Token> = runCatching {
+        authDataSource.login(socialPlatform).getToken()
+    }.onSuccess { token ->
+        tokenDataStore.updateData { Token(token.accessToken, token.refreshToken) }
+        Log.d("AuthRepoImpl", "${tokenDataStore.data.first()}")
+    }.onFailure {
+        Log.d("AuthRepoImpl", "$it 에러")
+    }
+
+    override suspend fun getToken(): Result<Token> = runCatching {
+        authDataSource.getToken().getToken()
+    }.onSuccess { token ->
+        tokenDataStore.updateData { Token(token.accessToken, token.refreshToken) }
+        Log.d("AuthRepoImpl", "${tokenDataStore.data.first()}")
+    }.onFailure {
+        Log.d("AuthRepoImpl", "$it 에러")
+    }
+}

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/repository/AuthRepositoryImpl.kt
@@ -2,7 +2,6 @@ package com.puzzling.puzzlingaos.data.repository
 
 import android.util.Log
 import androidx.datastore.core.DataStore
-import com.puzzling.puzzlingaos.data.datasource.local.UserDataSource
 import com.puzzling.puzzlingaos.data.datasource.remote.AuthDataSource
 import com.puzzling.puzzlingaos.data.entity.Token
 import com.puzzling.puzzlingaos.data.entity.User

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/repository/TokenRepositoryImpl.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/repository/TokenRepositoryImpl.kt
@@ -8,8 +8,8 @@ import javax.inject.Inject
 
 class TokenRepositoryImpl @Inject constructor(private val dataStore: DataStore<Token>) :
     TokenRepository {
-    override suspend fun setToken(token: String) {
-        dataStore.updateData { Token(token) }
+    override suspend fun setToken(accessToken: String) {
+        dataStore.updateData { Token(accessToken) }
     }
 
     override suspend fun getToken(): Token = dataStore.data.first()

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/repository/UserRepositoryImpl.kt
@@ -1,0 +1,16 @@
+package com.puzzling.puzzlingaos.data.repository
+
+import androidx.datastore.core.DataStore
+import com.puzzling.puzzlingaos.data.entity.User
+import com.puzzling.puzzlingaos.domain.repository.UserRepository
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+
+class UserRepositoryImpl @Inject constructor(private val dataStore: DataStore<User>) :
+    UserRepository {
+    override suspend fun setUserInfo(userInfo: User) {
+        dataStore.updateData { User(userInfo.memberId, userInfo.name) }
+    }
+
+    override suspend fun getUserInfo(): User = dataStore.data.first()
+}

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/service/AuthService.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/service/AuthService.kt
@@ -1,0 +1,17 @@
+package com.puzzling.puzzlingaos.data.service
+
+import com.puzzling.puzzlingaos.data.model.response.ResponseLoginDto
+import com.puzzling.puzzlingaos.data.model.response.ResponseTokenDto
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+interface AuthService {
+    @POST("auth")
+    suspend fun login(
+        @Body socialPlatform: String,
+    ): ResponseLoginDto
+
+    @GET("auth/token")
+    suspend fun getToken(): ResponseTokenDto
+}

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/service/AuthService.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/service/AuthService.kt
@@ -2,9 +2,7 @@ package com.puzzling.puzzlingaos.data.service
 
 import com.puzzling.puzzlingaos.data.model.request.RequestLoginDto
 import com.puzzling.puzzlingaos.data.model.response.ResponseLoginDto
-import com.puzzling.puzzlingaos.data.model.response.ResponseTokenDto
 import retrofit2.http.Body
-import retrofit2.http.GET
 import retrofit2.http.POST
 
 interface AuthService {
@@ -12,7 +10,4 @@ interface AuthService {
     suspend fun login(
         @Body socialPlatform: RequestLoginDto,
     ): ResponseLoginDto
-
-    @GET("api/v1/auth/token")
-    suspend fun getToken(): ResponseTokenDto
 }

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/service/AuthService.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/service/AuthService.kt
@@ -1,5 +1,6 @@
 package com.puzzling.puzzlingaos.data.service
 
+import com.puzzling.puzzlingaos.data.model.request.RequestLoginDto
 import com.puzzling.puzzlingaos.data.model.response.ResponseLoginDto
 import com.puzzling.puzzlingaos.data.model.response.ResponseTokenDto
 import retrofit2.http.Body
@@ -7,11 +8,11 @@ import retrofit2.http.GET
 import retrofit2.http.POST
 
 interface AuthService {
-    @POST("auth")
+    @POST("api/v1/auth")
     suspend fun login(
-        @Body socialPlatform: String,
+        @Body socialPlatform: RequestLoginDto,
     ): ResponseLoginDto
 
-    @GET("auth/token")
+    @GET("api/v1/auth/token")
     suspend fun getToken(): ResponseTokenDto
 }

--- a/app/src/main/java/com/puzzling/puzzlingaos/data/service/ReIssueTokenService.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/data/service/ReIssueTokenService.kt
@@ -1,0 +1,9 @@
+package com.puzzling.puzzlingaos.data.service
+
+import com.puzzling.puzzlingaos.data.model.response.ResponseTokenDto
+import retrofit2.http.GET
+
+interface ReIssueTokenService {
+    @GET("api/v1/auth/token")
+    suspend fun getToken(): ResponseTokenDto
+}

--- a/app/src/main/java/com/puzzling/puzzlingaos/di/ApiModule.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/di/ApiModule.kt
@@ -1,5 +1,6 @@
 package com.puzzling.puzzlingaos.di
 
+import com.puzzling.puzzlingaos.data.service.AuthService
 import com.puzzling.puzzlingaos.data.service.MyPageService
 import com.puzzling.puzzlingaos.data.service.PersonalReviewService
 import com.puzzling.puzzlingaos.data.service.ProjectService
@@ -39,4 +40,9 @@ object ApiModule {
     @Singleton
     fun provideWriteReviewService(@PuzzlingRetrofit retrofit: Retrofit): WriteReviewService =
         retrofit.create(WriteReviewService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideAuthService(@PuzzlingRetrofit retrofit: Retrofit): AuthService =
+        retrofit.create(AuthService::class.java)
 }

--- a/app/src/main/java/com/puzzling/puzzlingaos/di/ApiModule.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/di/ApiModule.kt
@@ -4,6 +4,7 @@ import com.puzzling.puzzlingaos.data.service.AuthService
 import com.puzzling.puzzlingaos.data.service.MyPageService
 import com.puzzling.puzzlingaos.data.service.PersonalReviewService
 import com.puzzling.puzzlingaos.data.service.ProjectService
+import com.puzzling.puzzlingaos.data.service.ReIssueTokenService
 import com.puzzling.puzzlingaos.data.service.TeamReviewService
 import com.puzzling.puzzlingaos.data.service.WriteReviewService
 import dagger.Module
@@ -45,4 +46,9 @@ object ApiModule {
     @Singleton
     fun provideAuthService(@PuzzlingRetrofit retrofit: Retrofit): AuthService =
         retrofit.create(AuthService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideReIssueTokenService(@ReIssueRetrofit retrofit: Retrofit): ReIssueTokenService =
+        retrofit.create(ReIssueTokenService::class.java)
 }

--- a/app/src/main/java/com/puzzling/puzzlingaos/di/DataSourceModule.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/di/DataSourceModule.kt
@@ -5,6 +5,7 @@ import com.puzzling.puzzlingaos.data.datasource.remote.MyPageDataSource
 import com.puzzling.puzzlingaos.data.datasource.remote.ProjectDataSource
 import com.puzzling.puzzlingaos.data.datasource.remote.TeamDashBoardDataSource
 import com.puzzling.puzzlingaos.data.datasource.remote.WriteReviewDataSource
+import com.puzzling.puzzlingaos.data.datasource.remote.impl.AuthDataSourceImpl
 import com.puzzling.puzzlingaos.data.datasource.remote.impl.MyDashBoardDataSourceImpl
 import com.puzzling.puzzlingaos.data.datasource.remote.impl.MyPageDataSourceImpl
 import com.puzzling.puzzlingaos.data.datasource.remote.impl.ProjectDataSourceImpl
@@ -38,4 +39,8 @@ abstract class DataSourceModule {
     @Singleton
     @Binds
     abstract fun providesWriteReviewDataSource(DataSourceImpl: WriteReviewDataSourceImpl): WriteReviewDataSource
+
+    @Singleton
+    @Binds
+    abstract fun providesAuthDataSource(DataSourceImpl: AuthDataSourceImpl): AuthDataSourceImpl
 }

--- a/app/src/main/java/com/puzzling/puzzlingaos/di/DataSourceModule.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/di/DataSourceModule.kt
@@ -1,5 +1,6 @@
 package com.puzzling.puzzlingaos.di
 
+import com.puzzling.puzzlingaos.data.datasource.remote.AuthDataSource
 import com.puzzling.puzzlingaos.data.datasource.remote.MyDashBoardDataSource
 import com.puzzling.puzzlingaos.data.datasource.remote.MyPageDataSource
 import com.puzzling.puzzlingaos.data.datasource.remote.ProjectDataSource
@@ -42,5 +43,5 @@ abstract class DataSourceModule {
 
     @Singleton
     @Binds
-    abstract fun providesAuthDataSource(DataSourceImpl: AuthDataSourceImpl): AuthDataSourceImpl
+    abstract fun providesAuthDataSource(DataSourceImpl: AuthDataSourceImpl): AuthDataSource
 }

--- a/app/src/main/java/com/puzzling/puzzlingaos/di/DataStoreModule.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/di/DataStoreModule.kt
@@ -5,7 +5,9 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.core.DataStoreFactory
 import androidx.datastore.dataStoreFile
 import com.puzzling.puzzlingaos.data.datasource.local.TokenDataSource
+import com.puzzling.puzzlingaos.data.datasource.local.UserDataSource
 import com.puzzling.puzzlingaos.data.entity.Token
+import com.puzzling.puzzlingaos.data.entity.User
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -27,6 +29,20 @@ object DataStoreModule {
     ): DataStore<Token> {
         return DataStoreFactory.create(
             serializer = tokenDataSource,
+            produceFile = {
+                appContext.dataStoreFile(DATA_STORE_FILE_NAME)
+            },
+        )
+    }
+
+    @Provides
+    @Singleton
+    fun provideUserDataStore(
+        @ApplicationContext appContext: Context,
+        userDataSource: UserDataSource,
+    ): DataStore<User> {
+        return DataStoreFactory.create(
+            serializer = userDataSource,
             produceFile = {
                 appContext.dataStoreFile(DATA_STORE_FILE_NAME)
             },

--- a/app/src/main/java/com/puzzling/puzzlingaos/di/DataStoreModule.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/di/DataStoreModule.kt
@@ -21,7 +21,7 @@ object DataStoreModule {
 
     @Provides
     @Singleton
-    fun providePreferencesDataStore(
+    fun provideTokenDataStore(
         @ApplicationContext appContext: Context,
         tokenDataSource: TokenDataSource,
     ): DataStore<Token> {

--- a/app/src/main/java/com/puzzling/puzzlingaos/di/DataStoreModule.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/di/DataStoreModule.kt
@@ -18,8 +18,8 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object DataStoreModule {
-    private const val USER_PREFERENCES_NAME = "user_preferences"
-    private const val DATA_STORE_FILE_NAME = "user_prefs.pb"
+    private const val USER_DATA_STORE_FILE_NAME = "user_prefs.pb"
+    private const val TOKEN_DATA_STORE_FILE_NAME = "token_prefs.pb"
 
     @Provides
     @Singleton
@@ -30,7 +30,7 @@ object DataStoreModule {
         return DataStoreFactory.create(
             serializer = tokenDataSource,
             produceFile = {
-                appContext.dataStoreFile(DATA_STORE_FILE_NAME)
+                appContext.dataStoreFile(TOKEN_DATA_STORE_FILE_NAME)
             },
         )
     }
@@ -44,7 +44,7 @@ object DataStoreModule {
         return DataStoreFactory.create(
             serializer = userDataSource,
             produceFile = {
-                appContext.dataStoreFile(DATA_STORE_FILE_NAME)
+                appContext.dataStoreFile(USER_DATA_STORE_FILE_NAME)
             },
         )
     }

--- a/app/src/main/java/com/puzzling/puzzlingaos/di/Qualifier.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/di/Qualifier.kt
@@ -5,3 +5,7 @@ import javax.inject.Qualifier
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class PuzzlingRetrofit
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ReIssueRetrofit

--- a/app/src/main/java/com/puzzling/puzzlingaos/di/RepositoryModule.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/di/RepositoryModule.kt
@@ -38,4 +38,8 @@ abstract class RepositoryModule {
     @Singleton
     @Binds
     abstract fun providesAuthRepository(repoImpl: AuthRepositoryImpl): AuthRepository
+
+    @Singleton
+    @Binds
+    abstract fun providesUserRepository(repoImpl: UserRepositoryImpl): UserRepository
 }

--- a/app/src/main/java/com/puzzling/puzzlingaos/di/RepositoryModule.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/di/RepositoryModule.kt
@@ -34,4 +34,8 @@ abstract class RepositoryModule {
     @Singleton
     @Binds
     abstract fun providesTokenRepository(repoImpl: TokenRepositoryImpl): TokenRepository
+
+    @Singleton
+    @Binds
+    abstract fun providesAuthRepository(repoImpl: AuthRepositoryImpl): AuthRepository
 }

--- a/app/src/main/java/com/puzzling/puzzlingaos/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/domain/repository/AuthRepository.kt
@@ -1,0 +1,10 @@
+package com.puzzling.puzzlingaos.domain.repository
+
+import com.puzzling.puzzlingaos.data.entity.Token
+
+interface AuthRepository {
+
+    suspend fun login(socialPlatform: String): Result<Token>
+
+    suspend fun getToken(): Result<Token>
+}

--- a/app/src/main/java/com/puzzling/puzzlingaos/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/domain/repository/AuthRepository.kt
@@ -1,10 +1,11 @@
 package com.puzzling.puzzlingaos.domain.repository
 
 import com.puzzling.puzzlingaos.data.entity.Token
+import com.puzzling.puzzlingaos.data.model.response.ResponseLoginDto
 
 interface AuthRepository {
 
-    suspend fun login(socialPlatform: String): Result<Token>
+    suspend fun login(socialPlatform: String): Result<ResponseLoginDto>
 
     suspend fun getToken(): Result<Token>
 }

--- a/app/src/main/java/com/puzzling/puzzlingaos/domain/repository/TokenRepository.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/domain/repository/TokenRepository.kt
@@ -3,7 +3,7 @@ package com.puzzling.puzzlingaos.domain.repository
 import com.puzzling.puzzlingaos.data.entity.Token
 
 interface TokenRepository {
-    suspend fun setToken(token: String)
+    suspend fun setToken(accessToken: String)
 
     suspend fun getToken(): Token
 }

--- a/app/src/main/java/com/puzzling/puzzlingaos/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/domain/repository/UserRepository.kt
@@ -1,0 +1,9 @@
+package com.puzzling.puzzlingaos.domain.repository
+
+import com.puzzling.puzzlingaos.data.entity.User
+
+interface UserRepository {
+
+    suspend fun setUserInfo(userInfo: User)
+    suspend fun getUserInfo(): User
+}

--- a/app/src/main/java/com/puzzling/puzzlingaos/domain/usecase/onboarding/GetLocalTokenUseCase.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/domain/usecase/onboarding/GetLocalTokenUseCase.kt
@@ -5,6 +5,9 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class PostTokenUseCase @Inject constructor(private val repository: TokenRepository) {
-    suspend operator fun invoke(token: String) = repository.setToken(token)
+class GetLocalTokenUseCase @Inject constructor(
+    private val repository: TokenRepository,
+) {
+
+    suspend operator fun invoke() = repository.getToken()
 }

--- a/app/src/main/java/com/puzzling/puzzlingaos/domain/usecase/onboarding/GetRemoteTokenUseCase.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/domain/usecase/onboarding/GetRemoteTokenUseCase.kt
@@ -1,0 +1,9 @@
+package com.puzzling.puzzlingaos.domain.usecase.onboarding
+
+import com.puzzling.puzzlingaos.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class GetRemoteTokenUseCase @Inject constructor(private val repository: AuthRepository) {
+
+    suspend operator fun invoke() = repository.getToken()
+}

--- a/app/src/main/java/com/puzzling/puzzlingaos/domain/usecase/onboarding/GetTokenUseCase.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/domain/usecase/onboarding/GetTokenUseCase.kt
@@ -6,8 +6,8 @@ import javax.inject.Singleton
 
 @Singleton
 class GetTokenUseCase @Inject constructor(
-    private val tokenRepository: TokenRepository,
+    private val repository: TokenRepository,
 ) {
 
-    suspend operator fun invoke() = tokenRepository.getToken()
+    suspend operator fun invoke() = repository.getToken()
 }

--- a/app/src/main/java/com/puzzling/puzzlingaos/domain/usecase/onboarding/GetUserUseCase.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/domain/usecase/onboarding/GetUserUseCase.kt
@@ -1,0 +1,11 @@
+package com.puzzling.puzzlingaos.domain.usecase.onboarding
+
+import com.puzzling.puzzlingaos.domain.repository.UserRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class GetUserUseCase @Inject constructor(private val repository: UserRepository) {
+
+    suspend operator fun invoke() = repository.getUserInfo()
+}

--- a/app/src/main/java/com/puzzling/puzzlingaos/domain/usecase/onboarding/PostLocalTokenUseCase.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/domain/usecase/onboarding/PostLocalTokenUseCase.kt
@@ -5,9 +5,6 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class GetTokenUseCase @Inject constructor(
-    private val repository: TokenRepository,
-) {
-
-    suspend operator fun invoke() = repository.getToken()
+class PostLocalTokenUseCase @Inject constructor(private val repository: TokenRepository) {
+    suspend operator fun invoke(token: String) = repository.setToken(token)
 }

--- a/app/src/main/java/com/puzzling/puzzlingaos/domain/usecase/onboarding/PostTokenUseCase.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/domain/usecase/onboarding/PostTokenUseCase.kt
@@ -5,6 +5,6 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class PostTokenUseCase @Inject constructor(private val tokenRepository: TokenRepository) {
-    suspend operator fun invoke(token: String) = tokenRepository.setToken(token)
+class PostTokenUseCase @Inject constructor(private val repository: TokenRepository) {
+    suspend operator fun invoke(token: String) = repository.setToken(token)
 }

--- a/app/src/main/java/com/puzzling/puzzlingaos/presentation/onboarding/LoginActivity.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/presentation/onboarding/LoginActivity.kt
@@ -25,8 +25,22 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_login
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        isAlreadyLogin()
         startKakaoLogin()
         isKakaoLoginSuccess()
+    }
+
+    private fun isAlreadyLogin() {
+        viewModel.checkIsAlreadyLogin()
+        viewModel.isAlreadyLogin.observe(this) { isAlreadyLogin ->
+            if (isAlreadyLogin) {
+                val intent =
+                    Intent(this@LoginActivity, ChooseJoinRegisterActivity::class.java)
+                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
+                startActivity(intent)
+                finish()
+            }
+        }
     }
 
     private fun startKakaoLogin() {

--- a/app/src/main/java/com/puzzling/puzzlingaos/presentation/onboarding/LoginActivity.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/presentation/onboarding/LoginActivity.kt
@@ -2,6 +2,7 @@ package com.puzzling.puzzlingaos.presentation.onboarding
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -39,6 +40,7 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_login
                 intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
                 startActivity(intent)
                 finish()
+                viewModel.getToken()
             }
         }
     }

--- a/app/src/main/java/com/puzzling/puzzlingaos/presentation/onboarding/LoginActivity.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/presentation/onboarding/LoginActivity.kt
@@ -2,7 +2,6 @@ package com.puzzling.puzzlingaos.presentation.onboarding
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -12,6 +11,7 @@ import com.puzzling.puzzlingaos.base.BaseActivity
 import com.puzzling.puzzlingaos.data.service.KakaoAuthService
 import com.puzzling.puzzlingaos.databinding.ActivityLoginBinding
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -22,7 +22,6 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_login
     lateinit var kakakoAuthService: KakaoAuthService
 
     private val viewModel: LoginViewModel by viewModels()
-
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -46,6 +45,8 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_login
                         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
                         startActivity(intent)
                         finish()
+                        delay(100)
+                        viewModel.login("KAKAO")
                     }
                 }
             }

--- a/app/src/main/java/com/puzzling/puzzlingaos/presentation/onboarding/LoginViewModel.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/presentation/onboarding/LoginViewModel.kt
@@ -46,10 +46,6 @@ class LoginViewModel @Inject constructor(
         }.handleResult(token, error)
     }
 
-    init {
-        getToken()
-    }
-
     fun login(socialPlatform: String) = viewModelScope.launch {
         Log.d("LoginActivity", "로그인 함수 호출")
         authRepository.login("KAKAO")

--- a/app/src/main/java/com/puzzling/puzzlingaos/presentation/onboarding/LoginViewModel.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/presentation/onboarding/LoginViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kakao.sdk.auth.model.OAuthToken
 import com.puzzling.puzzlingaos.data.datasource.local.LocalDataSource
+import com.puzzling.puzzlingaos.domain.repository.AuthRepository
 import com.puzzling.puzzlingaos.domain.usecase.onboarding.GetTokenUseCase
 import com.puzzling.puzzlingaos.domain.usecase.onboarding.PostTokenUseCase
 import com.puzzling.puzzlingaos.util.KakaoLoginCallback
@@ -18,6 +19,7 @@ import javax.inject.Inject
 class LoginViewModel @Inject constructor(
     private val postTokenUseCase: PostTokenUseCase,
     private val getTokenUseCase: GetTokenUseCase,
+    private val authRepository: AuthRepository,
 ) :
     ViewModel() {
     private val _isKakaoLogin = MutableStateFlow(false)
@@ -26,12 +28,17 @@ class LoginViewModel @Inject constructor(
     val kakaoLoginCallback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
         KakaoLoginCallback {
             _isKakaoLogin.value = true
-            Log.d("LoginViewModel", "토큰!! $token")
+            Log.d("LoginViewModel", "카카오 로그인 set 토큰 $token")
             LocalDataSource.setAccessToken("$token")
             viewModelScope.launch {
                 postTokenUseCase.invoke(it)
-                Log.d("LoginViewModel", "토큰!! usecase ${getTokenUseCase.invoke()}")
+                Log.d("LoginViewModel", "카카오 로그인 get 토큰 ${getTokenUseCase.invoke()}")
             }
         }.handleResult(token, error)
+    }
+
+    fun login(socialPlatform: String) = viewModelScope.launch {
+        Log.d("LoginActivity", "로그인 함수 호출")
+        authRepository.login("KAKAO")
     }
 }

--- a/app/src/main/java/com/puzzling/puzzlingaos/presentation/onboarding/LoginViewModel.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/presentation/onboarding/LoginViewModel.kt
@@ -8,9 +8,10 @@ import androidx.lifecycle.viewModelScope
 import com.kakao.sdk.auth.model.OAuthToken
 import com.puzzling.puzzlingaos.data.datasource.local.LocalDataSource
 import com.puzzling.puzzlingaos.domain.repository.AuthRepository
-import com.puzzling.puzzlingaos.domain.usecase.onboarding.GetTokenUseCase
+import com.puzzling.puzzlingaos.domain.usecase.onboarding.GetLocalTokenUseCase
+import com.puzzling.puzzlingaos.domain.usecase.onboarding.GetRemoteTokenUseCase
 import com.puzzling.puzzlingaos.domain.usecase.onboarding.GetUserUseCase
-import com.puzzling.puzzlingaos.domain.usecase.onboarding.PostTokenUseCase
+import com.puzzling.puzzlingaos.domain.usecase.onboarding.PostLocalTokenUseCase
 import com.puzzling.puzzlingaos.util.KakaoLoginCallback
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,9 +21,10 @@ import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
-    private val postTokenUseCase: PostTokenUseCase,
-    private val getTokenUseCase: GetTokenUseCase,
+    private val postLocalTokenUseCase: PostLocalTokenUseCase,
+    private val getLocalTokenUseCase: GetLocalTokenUseCase,
     private val getUserUseCase: GetUserUseCase,
+    private val getRemoteTokenUseCase: GetRemoteTokenUseCase,
     private val authRepository: AuthRepository,
 ) :
     ViewModel() {
@@ -38,10 +40,14 @@ class LoginViewModel @Inject constructor(
             Log.d("LoginViewModel", "카카오 로그인 set 토큰 $token")
             LocalDataSource.setAccessToken("$token")
             viewModelScope.launch {
-                postTokenUseCase.invoke(it)
-                Log.d("LoginViewModel", "카카오 로그인 get 토큰 ${getTokenUseCase.invoke()}")
+                postLocalTokenUseCase.invoke(it)
+                Log.d("LoginViewModel", "카카오 로그인 get 토큰 ${getLocalTokenUseCase.invoke()}")
             }
         }.handleResult(token, error)
+    }
+
+    init {
+        getToken()
     }
 
     fun login(socialPlatform: String) = viewModelScope.launch {
@@ -53,5 +59,9 @@ class LoginViewModel @Inject constructor(
         var userInfo = getUserUseCase.invoke()
         _isAlreadyLogin.value = !userInfo.name.isNullOrBlank()
         Log.d("userInfo", "$userInfo")
+    }
+
+    fun getToken() = viewModelScope.launch {
+        getRemoteTokenUseCase.invoke()
     }
 }

--- a/app/src/main/java/com/puzzling/puzzlingaos/presentation/onboarding/LoginViewModel.kt
+++ b/app/src/main/java/com/puzzling/puzzlingaos/presentation/onboarding/LoginViewModel.kt
@@ -1,12 +1,15 @@
 package com.puzzling.puzzlingaos.presentation.onboarding
 
 import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kakao.sdk.auth.model.OAuthToken
 import com.puzzling.puzzlingaos.data.datasource.local.LocalDataSource
 import com.puzzling.puzzlingaos.domain.repository.AuthRepository
 import com.puzzling.puzzlingaos.domain.usecase.onboarding.GetTokenUseCase
+import com.puzzling.puzzlingaos.domain.usecase.onboarding.GetUserUseCase
 import com.puzzling.puzzlingaos.domain.usecase.onboarding.PostTokenUseCase
 import com.puzzling.puzzlingaos.util.KakaoLoginCallback
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -19,11 +22,15 @@ import javax.inject.Inject
 class LoginViewModel @Inject constructor(
     private val postTokenUseCase: PostTokenUseCase,
     private val getTokenUseCase: GetTokenUseCase,
+    private val getUserUseCase: GetUserUseCase,
     private val authRepository: AuthRepository,
 ) :
     ViewModel() {
     private val _isKakaoLogin = MutableStateFlow(false)
     val isKakaoLogin = _isKakaoLogin.asStateFlow()
+
+    private val _isAlreadyLogin = MutableLiveData<Boolean>()
+    val isAlreadyLogin: LiveData<Boolean> get() = _isAlreadyLogin
 
     val kakaoLoginCallback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
         KakaoLoginCallback {
@@ -40,5 +47,11 @@ class LoginViewModel @Inject constructor(
     fun login(socialPlatform: String) = viewModelScope.launch {
         Log.d("LoginActivity", "로그인 함수 호출")
         authRepository.login("KAKAO")
+    }
+
+    fun checkIsAlreadyLogin() = viewModelScope.launch {
+        var userInfo = getUserUseCase.invoke()
+        _isAlreadyLogin.value = !userInfo.name.isNullOrBlank()
+        Log.d("userInfo", "$userInfo")
     }
 }


### PR DESCRIPTION
## ✍️ 작업한 내용
- 자동 로그인 구현
- 로그인 api 연결
- 토큰 재발급 api 연결


## ✔️ PR point
- 토큰 재발급 api의 경우 따로 헤더에 Refresh 토큰 넣어야 해서, Retrofit 모듈 따로 만들었습니다.



## 📸 스크린샷



## 🍀 관련 이슈
- close #100